### PR TITLE
Add base alignment default

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ cd plateau2minecraft/
 poetry run python -m plateau2minecraft --target data/13100_tokyo23-ku_2022_citygml_1_2_op/udx/bldg/53393503_bldg_6697_2_op.gml --output data/output/ --print-min-z
 
 # Step2: use the printed value as base height when converting other features
+#        if omitted, `--base-z` defaults to 0
 poetry run python -m plateau2minecraft --target <non_building_gml> --output data/output/ --base-z <height>
 ```
 

--- a/src/plateau2minecraft/__main__.py
+++ b/src/plateau2minecraft/__main__.py
@@ -28,8 +28,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--base-z",
         type=float,
-        default=None,
-        help="align all objects so that their lowest Z matches the specified height",
+        default=0.0,
+        help="align all objects so that their lowest Z matches the specified height (default: 0)",
     )
     parser.add_argument(
         "--print-min-z",
@@ -50,10 +50,9 @@ if __name__ == "__main__":
         point_cloud = voxelize(triangle_mesh)
         point_cloud = assign(point_cloud, feature_type)
 
-        if args.base_z is not None:
-            current_min_z = point_cloud.vertices[:, 2].min()
-            offset = args.base_z - current_min_z
-            point_cloud.vertices[:, 2] += offset
+        current_min_z = point_cloud.vertices[:, 2].min()
+        offset = args.base_z - current_min_z
+        point_cloud.vertices[:, 2] += offset
 
         point_cloud_list.append(point_cloud)
         logging.info(f"Processing end: {file_path}")
@@ -67,4 +66,3 @@ if __name__ == "__main__":
 
     logging.info(f"To : {args.target}")
     region = Minecraft(merged).build_region(args.output)
-


### PR DESCRIPTION
## Summary
- default `--base-z` to 0 so every feature is aligned to a common base height
- document the default in the README

## Testing
- `poetry run ruff check src/plateau2minecraft/__main__.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688940c10ca8832d9e7d4815d8777b50