### PR TITLE
fix feature type detection on Windows paths

### DIFF
--- a/src/plateau2minecraft/__main__.py
+++ b/src/plateau2minecraft/__main__.py
@@ -11,8 +11,8 @@ from plateau2minecraft.voxelizer import voxelize
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
-def _extract_feature_type(file_path: str) -> str:
-    return file_path.split("/")[-1].split("_")[1]
+def _extract_feature_type(file_path: Path) -> str:
+    return file_path.stem.split("_")[1]
 
 
 if __name__ == "__main__":
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     point_cloud_list = []
     for file_path in args.target:
         logging.info(f"Processing start: {file_path}")
-        feature_type = _extract_feature_type(str(file_path))
+        feature_type = _extract_feature_type(file_path)
 
         logging.info(f"Triangulation: {file_path}")
         triangle_mesh = get_triangle_meshs(file_path, feature_type)


### PR DESCRIPTION
## Summary
- handle Windows-style paths when extracting CityGML feature types

## Testing
- `poetry run pytest`
- `poetry run ruff check src/plateau2minecraft/__main__.py`
- `poetry run black --check src/plateau2minecraft/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_688aa055be54832d8fca969a8af7a7eb